### PR TITLE
添加 Swift 包配置及忽略文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Xcode
+build/
+DerivedData/
+*.xcworkspace
+*.xcuserstate
+*.xcodeproj/
+.idea/
+# Swift Package Manager
+/.build
+Packages/
+# macOS files
+.DS_Store
+# SwiftPM config
+.swiftpm
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.8
+import PackageDescription
+
+let package = Package(
+    name: "GlowBoard",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .executable(name: "GlowBoard", targets: ["GlowBoard"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "GlowBoard",
+            path: "Sources/GlowBoard"
+        ),
+        .testTarget(
+            name: "GlowBoardTests",
+            dependencies: ["GlowBoard"],
+            path: "Tests/GlowBoardTests"
+        )
+    ]
+)

--- a/Sources/GlowBoard/main.swift
+++ b/Sources/GlowBoard/main.swift
@@ -1,0 +1,1 @@
+print("GlowBoard app placeholder")

--- a/Tests/GlowBoardTests/GlowBoardTests.swift
+++ b/Tests/GlowBoardTests/GlowBoardTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import GlowBoard
+
+final class GlowBoardTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertEqual(1 + 1, 2)
+    }
+}


### PR DESCRIPTION
## 变更内容
- 新增 `.gitignore` 以排除 Xcode、SwiftPM 及 macOS 生成文件
- 创建 `Package.swift`，定义 iOS 平台的 Swift 包
- 添加示例源代码 `Sources/GlowBoard/main.swift`
- 添加基础单元测试 `Tests/GlowBoardTests/GlowBoardTests.swift`

## 测试结果
- `swift test` 全部通过

------
https://chatgpt.com/codex/tasks/task_e_686ba2d11ae08332bc8e327832a00d7e