### PR TITLE
添加应用内购买架构文档并补充代码接口

### DIFF
--- a/Docs/in_app_purchase.md
+++ b/Docs/in_app_purchase.md
@@ -1,0 +1,23 @@
+# 应用内购买架构设计
+
+为了在 GlowBoard 中实现一个高内聚、低耦合的订阅功能，建议按现有分层模式新增「购买」模块。该模块提供一月自动续订和一年 99 元的付费方案，并通过协议解耦业务逻辑与 StoreKit 实现。
+
+## 分层关系
+- **Domain**：定义 `SubscriptionPlan` 数据结构与 `PurchaseService` 协议，声明购买与恢复接口。
+- **Infrastructure**：实现 `PurchaseService`，具体使用 StoreKit2 与苹果后台交互。
+- **Presentation**：通过依赖 `PurchaseService` 展示可选方案并触发购买，不直接依赖 StoreKit。
+
+这种划分使界面层无需了解底层实现，方便后续替换或单元测试。
+
+## 订阅方案示例
+1. `monthly`：1 个月自动续订。
+2. `annual`：1 年价格 99 元，可按年订阅。
+
+`PurchaseService` 返回以上计划供界面展示，实际售价与产品标识在 App Store Connect 配置，由 StoreKit 查询。
+
+## 实现要点
+- 使用 `async/await` 处理购买与恢复流程，保持界面响应。
+- 在 Infrastructure 层封装对 `Product.purchase()` 和 `Transaction.currentEntitlements` 的调用。
+- 通过依赖注入将 `PurchaseService` 实例传递给需要的视图或 ViewModel，保持模块间低耦合。
+
+通过以上架构，GlowBoard 可以在保持代码整洁的同时，为用户提供稳定的订阅功能。

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ GlowBoard 是一款面向 iOS 用户的文本提词应用，主打极简、自�
 - `design_philosophy.md`—设计理念
 - `system_design.md`—架构与技术选型
 - `code_architecture.md`—代码架构与模块划分
+- `in_app_purchase.md`—应用内购买架构
 
 本库目前不含实际代码，文档可作为后续实现的参考。
 

--- a/Sources/Domain/PurchaseService.swift
+++ b/Sources/Domain/PurchaseService.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Protocol describing basic purchase interactions.
+public protocol PurchaseService {
+    /// Returns available subscription plans.
+    func availablePlans() -> [SubscriptionPlan]
+
+    /// Initiates purchase of a plan.
+    func purchase(plan: SubscriptionPlan) async throws
+
+    /// Restores previous transactions.
+    func restorePurchases() async throws
+}

--- a/Sources/Domain/SubscriptionPlan.swift
+++ b/Sources/Domain/SubscriptionPlan.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Represents a purchasable subscription option.
+public struct SubscriptionPlan: Equatable {
+    public let id: String
+    public let title: String
+    public let price: Decimal
+    public let duration: TimeInterval
+
+    public init(id: String, title: String, price: Decimal, duration: TimeInterval) {
+        self.id = id
+        self.title = title
+        self.price = price
+        self.duration = duration
+    }
+}

--- a/Sources/Infrastructure/StoreKitPurchaseService.swift
+++ b/Sources/Infrastructure/StoreKitPurchaseService.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Domain
+#if canImport(StoreKit)
+import StoreKit
+#endif
+
+/// StoreKit-based implementation of PurchaseService.
+public final class StoreKitPurchaseService: PurchaseService {
+    private let plans: [SubscriptionPlan]
+
+    public init(plans: [SubscriptionPlan]) {
+        self.plans = plans
+    }
+
+    public func availablePlans() -> [SubscriptionPlan] {
+        plans
+    }
+
+    public func purchase(plan: SubscriptionPlan) async throws {
+        // TODO: integrate with StoreKit purchase API
+    }
+
+    public func restorePurchases() async throws {
+        // TODO: integrate with StoreKit restore API
+    }
+}


### PR DESCRIPTION
## 更新内容
- 新增 `Docs/in_app_purchase.md` 说明订阅功能的分层设计
- 在 README 中列出该文档
- 新增 `SubscriptionPlan` 结构体及 `PurchaseService` 协议
- 添加基于 StoreKit 的 `StoreKitPurchaseService` 实现示例

## 测试
- `swift test` 编译失败，因环境缺少 `SwiftUI` 模块，无法运行测试

------
https://chatgpt.com/codex/tasks/task_e_686bb0d88908833296600f5acb86bfcf